### PR TITLE
Rails 4/Ruby 2  support

### DIFF
--- a/lib/active_record/connection_adapters/seamless_database_pool_adapter.rb
+++ b/lib/active_record/connection_adapters/seamless_database_pool_adapter.rb
@@ -149,10 +149,10 @@ module ActiveRecord
       end
       
       def initialize(connection, logger, master_connection, read_connections, pool_weights)
-        super(connection, logger)
-        
         @master_connection = master_connection
         @read_connections = read_connections.dup.freeze
+        
+        super(connection, logger)
         
         @weighted_read_connections = []
         pool_weights.each_pair do |conn, weight|


### PR DESCRIPTION
For us at least, this fixes issue #15 in regards to Rails 4 and Ruby 2.0 support for this gem. I honestly have no idea why moving those two lines above the `super` call works, but for some reason after `super` is called master_connection and read_connections both become nil. When this happens, the error in #15 occurs. Moving the assignment above the `super` call somehow fixes it.

I'm not sure if this is caused by a change in Rails 4 or in Ruby 2.0 though.
