### PR TITLE
Added exec_query to read only method list. Looks like only place used in...

### DIFF
--- a/lib/active_record/connection_adapters/seamless_database_pool_adapter.rb
+++ b/lib/active_record/connection_adapters/seamless_database_pool_adapter.rb
@@ -89,7 +89,7 @@ module ActiveRecord
           return const_get(adapter_class_name) if const_defined?(adapter_class_name, false)
           
           # Define methods to proxy to the appropriate pool
-          read_only_methods = [:select, :select_rows, :execute, :tables, :columns]
+          read_only_methods = [:select, :select_rows, :execute, :tables, :columns, :exec_query]
           clear_cache_methods = [:insert, :update, :delete]
           
           # Get a list of all methods redefined by the underlying adapter. These will be


### PR DESCRIPTION
In ActiveRecord 3.2 :pluck uses exec_query to query database. currently exec_query is proxyed using master always. However pluck is a read only call and only place in ActiveRecord 3.2 exec_query is used. Adding exec_query to the list of read only methods so that .pluck(:id) etc will use the configured pool instead of always the master pool.
