### PR TITLE
include private instance methods of the adapter class

### DIFF
--- a/lib/active_record/connection_adapters/seamless_database_pool_adapter.rb
+++ b/lib/active_record/connection_adapters/seamless_database_pool_adapter.rb
@@ -99,6 +99,7 @@ module ActiveRecord
           override_classes.each do |connection_class|
             master_methods.concat(connection_class.public_instance_methods(false))
             master_methods.concat(connection_class.protected_instance_methods(false))
+            master_methods.concat(connection_class.private_instance_methods(false))
           end
           master_methods = master_methods.collect{|m| m.to_sym}.uniq
           master_methods -= public_instance_methods(false) + protected_instance_methods(false) + private_instance_methods(false)

--- a/spec/connection_adapters_spec.rb
+++ b/spec/connection_adapters_spec.rb
@@ -230,6 +230,19 @@ describe "Test connection adapters" do
             
             with_driver.string.should == without_driver.string
           end
+
+          it "should allow for database specific types" do 
+            if adapter == "postgresql"
+              SeamlessDatabasePool.use_master_connection do
+                connection.enable_extension "hstore" 
+                connection.create_table(:pg) do |t|
+                  t.hstore :my_hash
+                end
+              end
+              connection.drop_table(:pg)
+            end
+          end
+          
         end
       end
     end


### PR DESCRIPTION
Seamless database doesn't load private methods of the other adapters which reduces functionality.

For example, without ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#create_table_definition we get none of the native_database_types of PostgreSQL, at least in migrations.  

Fixes https://github.com/bdurand/seamless_database_pool/issues/17
