### PR TITLE
Add ActiveRecord 5 compatibility

### DIFF
--- a/lib/active_record/connection_adapters/seamless_database_pool_adapter.rb
+++ b/lib/active_record/connection_adapters/seamless_database_pool_adapter.rb
@@ -35,7 +35,7 @@ module ActiveRecord
         end if config[:read_pool]
 
         klass = ::ActiveRecord::ConnectionAdapters::SeamlessDatabasePoolAdapter.adapter_class(master_connection)
-        klass.new(nil, logger, master_connection, read_connections, pool_weights)
+        klass.new(nil, logger, master_connection, read_connections, pool_weights, config)
       end
 
       def establish_adapter(adapter)
@@ -153,12 +153,12 @@ module ActiveRecord
         end
       end
       
-      def initialize(connection, logger, master_connection, read_connections, pool_weights)
+      def initialize(connection, logger, master_connection, read_connections, pool_weights, config)
         @master_connection = master_connection
         @read_connections = read_connections.dup.freeze
         
-        super(connection, logger)
-        
+        super(connection, logger, config)
+
         @weighted_read_connections = []
         pool_weights.each_pair do |conn, weight|
           weight.times{@weighted_read_connections << conn}

--- a/spec/database.yml
+++ b/spec/database.yml
@@ -27,6 +27,7 @@ postgresql:
 mysql:
   adapter: seamless_database_pool
   database: seamless_database_pool_test
+  prepared_statements: false
   username: root
   password:
   master:


### PR DESCRIPTION
ActiveRecord 5 (RC1) now determines if prepared statements should be enabled on adapter initialization based the config settings. See: https://github.com/rails/rails/commit/8200b3ba325be07ebd579c57c7104434b0bf036e

Without this update parameter bindings are not being applied and invalid SQL queries are being executed. For example:

```
 ActiveRecord::StatementInvalid:
       Mysql2::Error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '?' at line 1: SELECT  `mysql_test_models`.* FROM `mysql_test_models` ORDER BY `mysql_test_models`.`id` ASC LIMIT ?
```