### PR TITLE
update railtie to support Rails 5

### DIFF
--- a/lib/seamless_database_pool/railtie.rb
+++ b/lib/seamless_database_pool/railtie.rb
@@ -4,8 +4,12 @@ module SeamlessDatabasePool
       namespace :db do
         task :load_config do
           # Override seamless_database_pool configuration so db:* rake tasks work as expected.
-          original_config = Rails.application.config.database_configuration
-          ActiveRecord::Base.configurations = SeamlessDatabasePool.master_database_configuration(original_config)
+          module DatabaseConfiguration
+            def configurations
+              SeamlessDatabasePool.master_database_configuration(super.deep_dup)
+            end
+          end
+          ActiveRecord::Base.singleton_class.prepend(DatabaseConfiguration)
         end
       end
     end


### PR DESCRIPTION
Fixes #31.

Note that the use of `#prepend` in this PR requires Ruby >= 2.0.0, which would conflict with this gem's current compatibility back to 1.8.7.
