### PR TITLE
Fix Rails/ActiveSupport 5 deprecation warning

### DIFF
--- a/lib/active_record/connection_adapters/seamless_database_pool_adapter.rb
+++ b/lib/active_record/connection_adapters/seamless_database_pool_adapter.rb
@@ -62,19 +62,16 @@ module ActiveRecord
     end
     
     module SeamlessDatabasePoolBehavior
-      def self.included(base)
-        base.alias_method_chain(:reload, :seamless_database_pool)
-      end
       
       # Force reload to use the master connection since it's probably being called for a reason.
-      def reload_with_seamless_database_pool(*args)
+      def reload(*args)
         SeamlessDatabasePool.use_master_connection do
-          reload_without_seamless_database_pool(*args)
+          super *args
         end
       end
     end
     
-    include(SeamlessDatabasePoolBehavior) unless include?(SeamlessDatabasePoolBehavior)
+    prepend SeamlessDatabasePoolBehavior
   end
 
   module ConnectionAdapters


### PR DESCRIPTION
`Module#alias_method_chain` is deprecated in the latest release of Rails/ActiveSupport 5 in favor of `Module#prepend`. This PR replaces the use of `Module#alias_method_chain` with `Module#prepend`, fixing the deprecation warning when using this gem with Rails/ActiveSupport 5 as a dependency.

Note that `Module#prepend` requires Ruby 2.0 or greater.
