### PR TITLE
remove alias_method_chain deprecations

### DIFF
--- a/lib/seamless_database_pool/connection_statistics.rb
+++ b/lib/seamless_database_pool/connection_statistics.rb
@@ -9,42 +9,42 @@ module SeamlessDatabasePool
       base.alias_method_chain(:execute, :connection_statistics)
       base.alias_method_chain(:select, :connection_statistics)
     end
-  
+
     # Get the connection statistics
     def connection_statistics
       @connection_statistics ||= {}
     end
-    
+
     def reset_connection_statistics
       @connection_statistics = {}
     end
-  
+
     def update_with_connection_statistics(sql, name = nil)
       increment_connection_statistic(:update) do
         update_without_connection_statistics(sql, name)
       end
     end
-  
+
     def insert_with_connection_statistics(sql, name = nil)
       increment_connection_statistic(:insert) do
         insert_without_connection_statistics(sql, name)
       end
     end
-  
+
     def execute_with_connection_statistics(sql, name = nil)
       increment_connection_statistic(:execute) do
         execute_without_connection_statistics(sql, name)
       end
     end
-  
+
     protected
-  
+
     def select_with_connection_statistics(sql, name = nil, *args)
       increment_connection_statistic(:select) do
         select_without_connection_statistics(sql, name, *args)
       end
     end
-  
+
     def increment_connection_statistic(method)
       if @counting_pool_statistics
         yield

--- a/lib/seamless_database_pool/connection_statistics.rb
+++ b/lib/seamless_database_pool/connection_statistics.rb
@@ -3,13 +3,6 @@ module SeamlessDatabasePool
   # and it will keep track of how often each connection calls update, insert, execute,
   # or select.
   module ConnectionStatistics
-    def self.included(base)
-      base.alias_method_chain(:update, :connection_statistics)
-      base.alias_method_chain(:insert, :connection_statistics)
-      base.alias_method_chain(:execute, :connection_statistics)
-      base.alias_method_chain(:select, :connection_statistics)
-    end
-
     # Get the connection statistics
     def connection_statistics
       @connection_statistics ||= {}
@@ -19,29 +12,29 @@ module SeamlessDatabasePool
       @connection_statistics = {}
     end
 
-    def update_with_connection_statistics(sql, name = nil)
+    def update(sql, name = nil)
       increment_connection_statistic(:update) do
-        update_without_connection_statistics(sql, name)
+        super(sql, name)
       end
     end
 
-    def insert_with_connection_statistics(sql, name = nil)
+    def insert(sql, name = nil)
       increment_connection_statistic(:insert) do
-        insert_without_connection_statistics(sql, name)
+        super(sql, name)
       end
     end
 
-    def execute_with_connection_statistics(sql, name = nil)
+    def execute(sql, name = nil)
       increment_connection_statistic(:execute) do
-        execute_without_connection_statistics(sql, name)
+        super(sql, name)
       end
     end
 
     protected
 
-    def select_with_connection_statistics(sql, name = nil, *args)
+    def select(sql, name = nil, *args)
       increment_connection_statistic(:select) do
-        select_without_connection_statistics(sql, name, *args)
+        super(sql, name, *args)
       end
     end
 

--- a/lib/seamless_database_pool/controller_filter.rb
+++ b/lib/seamless_database_pool/controller_filter.rb
@@ -6,13 +6,12 @@ module SeamlessDatabasePool
   # when you need different connection types.
   #
   # Example:
-  # 
+  #
   #   ApplicationController < ActionController::Base
   #     include SeamlessDatabasePool::ControllerFilter
   #     use_database_pool :all => :persistent, [:save, :delete] => :master
   #     ...
-  
-  module ControllerFilter    
+  module ControllerFilter
     def self.included(base)
       unless base.respond_to?(:use_database_pool)
         base.extend(ClassMethods)
@@ -26,15 +25,14 @@ module SeamlessDatabasePool
         end
       end
     end
-    
+
     module ClassMethods
-      
       def seamless_database_pool_options
         return @seamless_database_pool_options if @seamless_database_pool_options
         @seamless_database_pool_options = superclass.seamless_database_pool_options.dup if superclass.respond_to?(:seamless_database_pool_options)
         @seamless_database_pool_options ||= {}
       end
-      
+
       # Call this method to set up the connection types that will be used for your actions.
       # The configuration is given as a hash where the key is the action name and the value is
       # the connection type (:master, :persistent, or :random). You can specify :all as the action
@@ -58,7 +56,7 @@ module SeamlessDatabasePool
         @seamless_database_pool_options = remapped_options
       end
     end
-    
+
     # Force the master connection to be used on the next request. This is very useful for the Post-Redirect pattern
     # where you post a request to your save action and then redirect the user back to the edit action. By calling
     # this method, you won't have to worry if the replication engine is slower than the redirect. Normally you
@@ -68,34 +66,34 @@ module SeamlessDatabasePool
     def use_master_db_connection_on_next_request
       session[:next_request_db_connection] = :master if session
     end
-    
+
     def seamless_database_pool_options
       self.class.seamless_database_pool_options
     end
-    
+
     # Rails 3.x hook for setting the read connection for the request.
     def process_with_seamless_database_pool(action, *args)
       set_read_only_connection_for_block(action) do
         process_without_seamless_database_pool(action, *args)
       end
     end
-    
+
     def redirect_to_with_seamless_database_pool(options = {}, response_status = {})
       if SeamlessDatabasePool.read_only_connection_type(nil) == :master
         use_master_db_connection_on_next_request
       end
       redirect_to_without_seamless_database_pool(options, response_status)
     end
-    
+
     private
-    
+
     # Rails 2.x hook for setting the read connection for the request.
     def perform_action_with_seamless_database_pool(*args)
       set_read_only_connection_for_block(action_name) do
         perform_action_without_seamless_database_pool(*args)
       end
     end
-    
+
     # Set the read only connection for a block. Used to set the connection for a controller action.
     def set_read_only_connection_for_block(action)
       read_pool_method = nil
@@ -103,7 +101,7 @@ module SeamlessDatabasePool
         read_pool_method = session[:next_request_db_connection]
         session.delete(:next_request_db_connection) if session[:next_request_db_connection]
       end
-      
+
       read_pool_method ||= seamless_database_pool_options[action.to_sym] || seamless_database_pool_options[:all]
       if read_pool_method
         SeamlessDatabasePool.set_read_only_connection_type(read_pool_method) do

--- a/spec/connection_statistics_spec.rb
+++ b/spec/connection_statistics_spec.rb
@@ -1,32 +1,31 @@
 require 'spec_helper'
 
 describe SeamlessDatabasePool::ConnectionStatistics do
-  
   module SeamlessDatabasePool
     class ConnectionStatisticsTester
       def insert (sql, name = nil)
         "INSERT #{sql}/#{name}"
       end
-      
+
       def update (sql, name = nil)
         execute(sql)
         "UPDATE #{sql}/#{name}"
       end
-      
+
       def execute (sql, name = nil)
         "EXECUTE #{sql}/#{name}"
       end
-      
+
       protected
-      
+
       def select (sql, name = nil, binds = [])
         "SELECT #{sql}/#{name}"
       end
-      
-      include ::SeamlessDatabasePool::ConnectionStatistics
+
+      prepend ::SeamlessDatabasePool::ConnectionStatistics
     end
   end
-  
+
   it "should increment statistics on update" do
     connection = SeamlessDatabasePool::ConnectionStatisticsTester.new
     connection.update('SQL', 'name').should == "UPDATE SQL/name"
@@ -34,7 +33,7 @@ describe SeamlessDatabasePool::ConnectionStatistics do
     connection.update('SQL 2').should == "UPDATE SQL 2/"
     connection.connection_statistics.should == {:update => 2}
   end
-  
+
   it "should increment statistics on insert" do
     connection = SeamlessDatabasePool::ConnectionStatisticsTester.new
     connection.insert('SQL', 'name').should == "INSERT SQL/name"
@@ -42,7 +41,7 @@ describe SeamlessDatabasePool::ConnectionStatistics do
     connection.insert('SQL 2').should == "INSERT SQL 2/"
     connection.connection_statistics.should == {:insert => 2}
   end
-  
+
   it "should increment statistics on execute" do
     connection = SeamlessDatabasePool::ConnectionStatisticsTester.new
     connection.execute('SQL', 'name').should == "EXECUTE SQL/name"
@@ -50,7 +49,7 @@ describe SeamlessDatabasePool::ConnectionStatistics do
     connection.execute('SQL 2').should == "EXECUTE SQL 2/"
     connection.connection_statistics.should == {:execute => 2}
   end
-  
+
   it "should increment statistics on select" do
     connection = SeamlessDatabasePool::ConnectionStatisticsTester.new
     connection.send(:select, 'SQL', 'name').should == "SELECT SQL/name"
@@ -58,14 +57,14 @@ describe SeamlessDatabasePool::ConnectionStatistics do
     connection.send(:select, 'SQL 2').should == "SELECT SQL 2/"
     connection.connection_statistics.should == {:select => 2}
   end
-  
+
   it "should increment counts only once within a block" do
     connection = SeamlessDatabasePool::ConnectionStatisticsTester.new
     expect(connection).to receive(:execute).with('SQL')
     connection.update('SQL')
     connection.connection_statistics.should == {:update => 1}
   end
-  
+
   it "should be able to clear the statistics" do
     connection = SeamlessDatabasePool::ConnectionStatisticsTester.new
     connection.update('SQL')
@@ -73,5 +72,5 @@ describe SeamlessDatabasePool::ConnectionStatistics do
     connection.reset_connection_statistics
     connection.connection_statistics.should == {}
   end
-  
+
 end

--- a/spec/controller_filter_spec.rb
+++ b/spec/controller_filter_spec.rb
@@ -1,45 +1,45 @@
 require 'spec_helper'
 
 describe "SeamlessDatabasePool::ControllerFilter" do
-  
+
   module SeamlessDatabasePool
     class TestApplicationController
       attr_reader :session
-      
+
       def initialize(session)
         @session = session
       end
-      
+
       def process(action, *args)
         send action
       end
-      
+
       def redirect_to (options = {}, response_status = {})
         options
       end
-      
+
       def base_action
         ::SeamlessDatabasePool.read_only_connection_type
       end
     end
-    
+
     class TestBaseController < TestApplicationController
       include ::SeamlessDatabasePool::ControllerFilter
 
       use_database_pool :read => :persistent
-      
+
       def read
         ::SeamlessDatabasePool.read_only_connection_type
       end
-      
+
       def other
         ::SeamlessDatabasePool.read_only_connection_type
       end
     end
-    
+
     class TestOtherController < TestBaseController
       use_database_pool :all => :random, [:edit, :save, :redirect_master_action] => :master
-      
+
       def edit
         ::SeamlessDatabasePool.read_only_connection_type
       end
@@ -47,102 +47,102 @@ describe "SeamlessDatabasePool::ControllerFilter" do
       def save
         ::SeamlessDatabasePool.read_only_connection_type
       end
-      
+
       def redirect_master_action
         redirect_to(:action => :read)
       end
-      
+
       def redirect_read_action
         redirect_to(:action => :read)
       end
     end
-  
+
     class TestRails2ApplicationController < TestApplicationController
       attr_reader :action_name
-    
+
       def process(action, *args)
         @action_name = action
         perform_action
       end
-    
+
       private
-    
+
       def perform_action
         send action_name
       end
     end
-  
+
     class TestRails2BaseController < TestRails2ApplicationController
       include ::SeamlessDatabasePool::ControllerFilter
 
       use_database_pool :read => :persistent
-    
+
       def read
         ::SeamlessDatabasePool.read_only_connection_type
       end
     end
   end
-  
+
   let(:session){Hash.new}
   let(:controller){SeamlessDatabasePool::TestOtherController.new(session)}
-  
+
   it "should work with nothing set" do
     controller = SeamlessDatabasePool::TestApplicationController.new(session)
     controller.process('base_action').should == :master
   end
-  
+
   it "should allow setting a connection type for a single action" do
     controller = SeamlessDatabasePool::TestBaseController.new(session)
     controller.process('read').should == :persistent
   end
-  
+
   it "should allow setting a connection type for actions" do
     controller.process('edit').should == :master
     controller.process('save').should == :master
   end
-  
+
   it "should allow setting a connection type for all actions" do
     controller.process('other').should == :random
   end
-  
+
   it "should inherit the superclass' options" do
     controller.process('read').should == :persistent
   end
-  
+
   it "should be able to force using the master connection on the next request" do
     # First request
     controller.process('read').should == :persistent
     controller.use_master_db_connection_on_next_request
-    
+
     # Second request
     controller.process('read').should == :master
-    
+
     # Third request
     controller.process('read').should == :persistent
   end
-  
+
   it "should not break trying to force the master connection if sessions are not enabled" do
     controller.process('read').should == :persistent
     controller.use_master_db_connection_on_next_request
-    
+
     # Second request
     session.clear
     controller.process('read').should == :persistent
   end
-  
+
   it "should force the master connection on the next request for a redirect in master connection block" do
     controller = SeamlessDatabasePool::TestOtherController.new(session)
     controller.process('redirect_master_action').should == {:action => :read}
-    
+
     controller.process('read').should == :master
   end
 
   it "should not force the master connection on the next request for a redirect not in master connection block" do
     controller.process('redirect_read_action').should == {:action => :read}
-    
+
     controller.process('read').should == :persistent
   end
-  
+
   it "should work with a Rails 2 controller" do
     controller = SeamlessDatabasePool::TestRails2BaseController.new(session)
     controller.process('read').should == :persistent


### PR DESCRIPTION
Hello!

In Rails 5 `alias_method_chain` has been deprecated in favor of `Module::Prepend`. Since this gem requires ruby `~> 2.0` we can just replace the method and use `Module::Prepend` instead!

What do you think? 

- More info: http://www.justinweiss.com/articles/rails-5-module-number-prepend-and-the-end-of-alias-method-chain/

PS: My editor removes whitespaces automagically. You can check the diff ignoring whitespaces here https://github.com/bdurand/seamless_database_pool/pull/37/files?w=1
