### PR TITLE
#raw_connection proxy to master_connection

### DIFF
--- a/lib/active_record/connection_adapters/seamless_database_pool_adapter.rb
+++ b/lib/active_record/connection_adapters/seamless_database_pool_adapter.rb
@@ -172,6 +172,11 @@ module ActiveRecord
       def all_connections
         [@master_connection] + @read_connections
       end
+
+      # Returns the raw_connection for master
+      def raw_connection
+        @master_connection.raw_connection
+      end
       
       # Get the pool weight of a connection
       def pool_weight(connection)

--- a/spec/seamless_database_pool_adapter_spec.rb
+++ b/spec/seamless_database_pool_adapter_spec.rb
@@ -186,6 +186,11 @@ describe "SeamlessDatabasePoolAdapter" do
       expect(master_connection).to receive(:columns).with(:table).and_return(:retval)
       pool_connection.columns(:table).should == :retval
     end
+
+    it "#raw_connection returns the master raw_connection" do
+      expect(master_connection).to receive(:raw_connection).and_return(:base_connection)
+      pool_connection.raw_connection().should == :base_connection
+    end
   end
   
   context "fork to all connections" do


### PR DESCRIPTION
Currently SDP returns `nil` for `#raw_connection` of the standard adapter. This makes it incompatible with gems like Upsert (https://github.com/seamusabshere/upsert) due to the fact that Upsert tries to grab the raw_connection so it can skip ActiveRecord when generating queries for the database.

It makes sense to me that the `#raw_connection` would return the master connection's raw_connection.

The test I wrote is pretty basic, but more than that, the forked gem works with the Upsert gem without any problems.