### PR TITLE
Mark methods as protected

### DIFF
--- a/lib/seamless_database_pool/controller_filter.rb
+++ b/lib/seamless_database_pool/controller_filter.rb
@@ -52,6 +52,8 @@ module SeamlessDatabasePool
       end
     end
 
+    protected
+
     # Force the master connection to be used on the next request. This is very useful for the Post-Redirect pattern
     # where you post a request to your save action and then redirect the user back to the edit action. By calling
     # this method, you won't have to worry if the replication engine is slower than the redirect. Normally you
@@ -65,8 +67,6 @@ module SeamlessDatabasePool
     def seamless_database_pool_options
       self.class.seamless_database_pool_options
     end
-
-    private
 
     # Set the read only connection for a block. Used to set the connection for a controller action.
     def set_read_only_connection_for_block(action)

--- a/spec/controller_filter_spec.rb
+++ b/spec/controller_filter_spec.rb
@@ -112,7 +112,7 @@ describe "SeamlessDatabasePool::ControllerFilter" do
   it "should be able to force using the master connection on the next request" do
     # First request
     controller.process('read').should == :persistent
-    controller.use_master_db_connection_on_next_request
+    controller.send(:use_master_db_connection_on_next_request)
 
     # Second request
     controller.process('read').should == :master
@@ -123,7 +123,7 @@ describe "SeamlessDatabasePool::ControllerFilter" do
 
   it "should not break trying to force the master connection if sessions are not enabled" do
     controller.process('read').should == :persistent
-    controller.use_master_db_connection_on_next_request
+    controller.send(:use_master_db_connection_on_next_request)
 
     # Second request
     session.clear
@@ -146,5 +146,17 @@ describe "SeamlessDatabasePool::ControllerFilter" do
   it "should work with a Rails 2 controller" do
     controller = SeamlessDatabasePool::TestRails2BaseController.new(session)
     controller.process('read').should == :persistent
+  end
+
+  it "marks included methods as private" do
+    controller = SeamlessDatabasePool::TestBaseController.new(session)
+
+    controller.public_methods.should_not include(:use_master_db_connection_on_next_request)
+    controller.public_methods.should_not include(:seamless_database_pool_options)
+    controller.public_methods.should_not include(:set_read_only_connection_for_block)
+
+    controller.protected_methods.should include(:use_master_db_connection_on_next_request)
+    controller.protected_methods.should include(:seamless_database_pool_options)
+    controller.protected_methods.should include(:set_read_only_connection_for_block)
   end
 end


### PR DESCRIPTION
This ensures that when methods get included in the controller they are not marked as public and are potentially end-user accessible.

The `ControllerFilter` tends to be included int he `ApplicationController` which makes the matter worse as all the controllers inherit form this parent and have those methods marked as public.

/cc @bdurand 