### PR TITLE
Fix Ruby 2.7/3.0 kwargs handling

### DIFF
--- a/lib/active_record/connection_adapters/seamless_database_pool_adapter.rb
+++ b/lib/active_record/connection_adapters/seamless_database_pool_adapter.rb
@@ -182,7 +182,7 @@ module ActiveRecord
         false
       end
       
-      def transaction(options = {})
+      def transaction(**options)
         use_master_connection do
           super
         end


### PR DESCRIPTION
This is a fix for the tests failing with Ruby 3.0 due to

```
Failures:

  1) SeamlessDatabasePoolAdapter selecting a connection from the pool should use the master connection inside a transaction
     Failure/Error: super
     
     ArgumentError:
       wrong number of arguments (given 1, expected 0)
     # /usr/share/rubygems-integration/all/gems/activerecord-6.1.4.1/lib/active_record/connection_adapters/abstract/database_statements.rb:313:in `transaction'
     # ./lib/active_record/connection_adapters/seamless_database_pool_adapter.rb:188:in `block in transaction'
     # ./lib/active_record/connection_adapters/seamless_database_pool_adapter.rb:261:in `use_master_connection'
     # ./lib/active_record/connection_adapters/seamless_database_pool_adapter.rb:187:in `transaction'
     # ./spec/seamless_database_pool_adapter_spec.rb:146:in `block (4 levels) in <top (required)>'
     # ./lib/seamless_database_pool.rb:51:in `block in use_persistent_read_connection'
     # ./lib/seamless_database_pool.rb:78:in `set_read_only_connection_type'
     # ./lib/seamless_database_pool.rb:51:in `use_persistent_read_connection'
     # ./spec/seamless_database_pool_adapter_spec.rb:144:in `block (3 levels) in <top (required)>'

Finished in 0.77076 seconds (files took 0.59012 seconds to load)
64 examples, 1 failure

Failed examples:

rspec ./spec/seamless_database_pool_adapter_spec.rb:135 # SeamlessDatabasePoolAdapter selecting a connection from the pool should use the master connection inside a transaction
```